### PR TITLE
reword details of the notification message

### DIFF
--- a/scripts/matrix-notification/matrix-notification.go
+++ b/scripts/matrix-notification/matrix-notification.go
@@ -85,8 +85,8 @@ func main() {
 		}
 	}
 	pipelineMessage := fmt.Sprintf(
-		"Pipeline [%s](%s) in the repo *%s*, triggered by '%s'",
-		woodpeckerResult.Title, pipelineURL, cfg.RepoName, woodpeckerResult.Author,
+		"Pipeline #%d ([%s](%s)) in the repo *%s*, triggered by '%s'",
+		cfg.PipelineNumber, woodpeckerResult.Title, pipelineURL, cfg.RepoName, woodpeckerResult.Author,
 	)
 
 	if cfg.PRNumber != "" {

--- a/scripts/matrix-notification/matrix-notification.go
+++ b/scripts/matrix-notification/matrix-notification.go
@@ -95,10 +95,10 @@ func main() {
 	pipelineMessage += fmt.Sprintf(" commit '%s'", strings.Split(woodpeckerResult.Message, "\n")[0])
 
 	if allSuccess {
-		pipelineMessage += " passed ✅\n"
+		pipelineMessage = fmt.Sprintf("✅ %s passed\n", pipelineMessage)
 	} else {
-		pipelineMessage += fmt.Sprintf(
-			" failed ❌\n%s", workflowMessage,
+		pipelineMessage = fmt.Sprintf(
+			"❌ %s failed\n%s", pipelineMessage, workflowMessage,
 		)
 	}
 

--- a/scripts/matrix-notification/matrix-notification.go
+++ b/scripts/matrix-notification/matrix-notification.go
@@ -31,7 +31,7 @@ type Workflow struct {
 
 type PipelineResponse struct {
 	Author    string     `json:"author"`
-	Title     string     `json:"title"`
+	Message   string     `json:"message"`
 	Workflows []Workflow `json:"workflows"`
 }
 
@@ -46,7 +46,6 @@ type Config struct {
 	MatrixUser       string `env:"MATRIX_USER,required"`
 	MatrixPassword   string `env:"MATRIX_PASSWORD,required"`
 	RepoURL          string `env:"CI_REPO_URL,required"`
-	CommitMessage    string `env:"CI_COMMIT_MESSAGE,required"`
 	PRNumber         string `env:"CI_COMMIT_PULL_REQUEST"`
 }
 
@@ -85,15 +84,15 @@ func main() {
 		}
 	}
 	pipelineMessage := fmt.Sprintf(
-		"Pipeline #%d ([%s](%s)) in the repo *%s*, triggered by '%s'",
-		cfg.PipelineNumber, woodpeckerResult.Title, pipelineURL, cfg.RepoName, woodpeckerResult.Author,
+		"Pipeline [#%d](%s) in the repo *%s*, triggered by '%s'",
+		cfg.PipelineNumber, pipelineURL, cfg.RepoName, woodpeckerResult.Author,
 	)
 
 	if cfg.PRNumber != "" {
 		repoUrl, _ := url.JoinPath(cfg.RepoURL, "pull", cfg.PRNumber)
 		pipelineMessage += fmt.Sprintf(" for PR [#%s](%s) -", cfg.PRNumber, repoUrl)
 	}
-	pipelineMessage += fmt.Sprintf(" commit '%s'", cfg.CommitMessage)
+	pipelineMessage += fmt.Sprintf(" commit '%s'", strings.Split(woodpeckerResult.Message, "\n")[0])
 
 	if allSuccess {
 		pipelineMessage += " passed ✅\n"


### PR DESCRIPTION
1. show pipeline number instead of the title in the link (merge commits don't have a Title)
2. use the commit message from the woodpecker API response (get rid of one env. variable)
3. only show first line of the commit message (avoid long confusing outputs)

This is how it would look like
<img width="1183" height="714" alt="grafik" src="https://github.com/user-attachments/assets/da717402-dbf5-4c75-ac68-f7a926be9399" />

fixes #56