### PR TITLE
docs: update storage backend test with external MinIO setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/docker-compose_test_plan_template.md
+++ b/.github/ISSUE_TEMPLATE/docker-compose_test_plan_template.md
@@ -232,7 +232,11 @@ COMPOSE_FILE=docker-compose.yml:storage/decomposeds3.yml:traefik/opencloud.yml
     -v minio-data:/data \
     -e MINIO_ROOT_USER=opencloud \
     -e MINIO_ROOT_PASSWORD=opencloud-secret-key \
-    minio/minio server /data --console-address ":9001"
+    --privileged \
+    --user "root" \
+    --entrypoint="" \
+    alpine/minio:latest-release \
+    sh -c "mkdir -p /data/opencloud-bucket && minio server --console-address ':9001' /data"
 ```
 4. Verify that the MinIO container is running.
 5. Verify that OpenCloud connects to MinIO.


### PR DESCRIPTION
- we don't have `minio` in our https://github.com/opencloud-eu/opencloud-compose I added steps for starting MinIO separately in OpenCloud network.  
- deleted `testing/minio.yml`